### PR TITLE
Adjusted label for password setting field

### DIFF
--- a/sample/admintab.cpp
+++ b/sample/admintab.cpp
@@ -48,7 +48,7 @@ AdminTab::AdminTab(QWidget *parent)
     checkEnableReset = new QCheckBox("Enable Reset");
 
     lblCameraName = new QLabel("Camera Name");
-    lblAdminPassword = new QLabel("Admin Password");
+    lblAdminPassword = new QLabel("Set admin Password");
 
     QGridLayout *layout = new QGridLayout();
     layout->addWidget(lblCameraName,        0, 0, 1, 1);


### PR DESCRIPTION
Renamed it from 'Admin password' to 'Set admin password' to make it more obvious that it should be used to change the admin password, not to enter the current admin password for other updates to take effect.