### PR TITLE
Make sure to use correct string lengths and null termination

### DIFF
--- a/sample/admintab.cpp
+++ b/sample/admintab.cpp
@@ -144,9 +144,9 @@ void AdminTab::launchBrowserClicked()
     OnvifData *onvif_data = CP->camera->onvif_data;
     char host[128];
     extractHost(onvif_data->xaddrs, host);
-    char target[128];
-    strncpy(target, "start http://", 13);
-    strncat(target, host, strlen(host));
+    char target[sizeof(host)+13];
+    strncpy(target, "start http://", 14);
+    strncat(target, host, sizeof(target) - 14);
     system(target);
 }
 

--- a/sample/discovery.cpp
+++ b/sample/discovery.cpp
@@ -121,7 +121,8 @@ void Discovery::discover()
                         QString error_msg = onvif_data->last_error;
                         if (error_msg.contains("ter:NotAuthorized") || error_msg.contains("Unauthorized")) {
                             memset(&credential, 0, sizeof(credential));
-                            strncpy(credential.camera_name, onvif_data->camera_name, strlen(onvif_data->camera_name));
+                            strncpy(credential.camera_name, onvif_data->camera_name,
+                                    sizeof(credential.camera_name)-1);
                             emit login(&credential);
 
                             emit msg("starting login");
@@ -130,8 +131,12 @@ void Discovery::discover()
                             mutex.unlock();
 
                             if (credential.accept_requested) {
-                                strncpy(onvif_data->username, credential.username, strlen(credential.username));
-                                strncpy(onvif_data->password, credential.password, strlen(credential.password));
+                                strncpy(onvif_data->username, credential.username,
+                                        sizeof(onvif_data->username));
+                                onvif_data->username[sizeof(onvif_data->username)-1]=0;
+                                strncpy(onvif_data->password, credential.password,
+                                        sizeof(onvif_data->password));
+                                onvif_data->username[sizeof(onvif_data->password)-1]=0;
 
                                 if (fillRTSP(onvif_data) == 0) {
                                     loggedIn = true;


### PR DESCRIPTION
Correct a few compiler warnings reporting incorrect and/or unsafe string operations.