### PR TITLE
Skip devices without valid onvif data

### DIFF
--- a/onvif-util/src/onvif-util.cpp
+++ b/onvif-util/src/onvif-util.cpp
@@ -271,7 +271,11 @@ int main(int argc, char **argv)
 
 			int n = broadcast(onvif_session);
 			for (int i = 0; i < n; i++) {
-				prepareOnvifData(i, onvif_session, onvif_data);
+				bool success = prepareOnvifData(i, onvif_session, onvif_data);
+				if (!success) {
+					std::cout << "found invalid xaddrs in device response for device " << i << std::endl;
+					continue;
+				}
 				char host[128];
 				extractHost(onvif_data->xaddrs, host);
 				getHostname(onvif_data);


### PR DESCRIPTION
Fixes segmentation faults on responses from other devices supporting ws discovery.

When accessing a device, the scan evaluates all responses, and then fails to parse the XAddrs of devices which are not cameras. Skip these devices, like when scanning.

The possible segmentation fault in `extractHost()` should be fixed separately.

Fixes https://github.com/sr99622/libonvif/issues/106