### PR TITLE
onvif-util: simplify command parsing

### DIFF
--- a/onvif-util/src/onvif-util.cpp
+++ b/onvif-util/src/onvif-util.cpp
@@ -358,13 +358,11 @@ int main(int argc, char **argv)
 	}
 
 
-	char kybd_buf[128] = {0};
-	while (strcmp(kybd_buf, "quit")) {
-		memset(kybd_buf, 0, 128);
-		fgets(kybd_buf, 128, stdin);
-		kybd_buf[strcspn(kybd_buf, "\r\n")] = 0;
-
-		std::string cmd(kybd_buf);
+	std::string cmd;
+	while (cmd != "quit") {
+		std::cout << onvif_data->camera_name << "> ";
+		if (!std::getline(std::cin, cmd))
+			break;
 		if (cmd.length() == 0)
 			continue;
 		std::string arg;
@@ -524,7 +522,7 @@ int main(int argc, char **argv)
 					std::cout << "  DHCP:       " << (onvif_data->dhcp_enabled ? "YES" : "NO") << "\n" << std::endl;
 				}
 				else { 
-					std::cout << "  Unrecognized command, use onvif-util -h to see help\n" << std::endl;
+					std::cout << "  Unrecognized command \"" << args[0] << "\", type \"help\" to see help\n" << std::endl;
 				}
 			}
 			else if (args[0] == "set") {
@@ -757,10 +755,8 @@ int main(int argc, char **argv)
 			}
 			else if (args[0] == "reboot") {
 				std::cout << "  Are you sure you want to reboot?  Type yes to confirm\n" << std::endl;
-				memset(kybd_buf, 0, 128);
-				fgets(kybd_buf, 128, stdin);
-				kybd_buf[strcspn(kybd_buf, "\r\n")] = 0;
-				std::string reply(kybd_buf);
+				std::string reply;
+				std::getline(std::cin, reply);
 				if (reply == "yes") {
 					if (rebootCamera(onvif_data)) throw std::runtime_error(cat("reboot camera - ", onvif_data->last_error));
 					std::cout << "  Camera is rebooting...\n" 
@@ -840,8 +836,8 @@ int main(int argc, char **argv)
 				showHelp();
 			}
 			else { 
-				if (strcmp(kybd_buf, "quit"))
-					std::cout << " Unrecognized command, type help to see help\n" << std::endl;
+				if (cmd != "quit")
+					std::cout << " Unrecognized command \"" << args[0] << "\", type \"help\" to see help\n" << std::endl;
 			}
 		}
 		catch (std::exception& e) {


### PR DESCRIPTION
Use std::getline and std::cin.
This also avoids looping on special input such as Ctrl+D.

Also add a prompt, to make it more clear that input is requested.

Tested only on Linux.