### PR TITLE
Update install-onvif-gui.py for zypper

### DIFF
--- a/assets/scripts/install-onvif-gui.py
+++ b/assets/scripts/install-onvif-gui.py
@@ -244,7 +244,8 @@ class Install():
                 if pkg_mgr == "pacman":
                     ...
                 if pkg_mgr == "zypper":
-                    self.install_package(pkg_mgr, "libxcb-cursor-devel")
+                    self.install_package(pkg_mgr, "libxcb-cursor0")
+                    self.install_package(pkg_mgr, "libgthread-2_0-0")
 
             else:
                 print(f"Unsupported display protocol: {protocol}")


### PR DESCRIPTION
Added Zypper (Opensuse Tumbleweed) in the install script. These changes seem to have installed it fine and i can run the GUI and view cameras.

Had to use `zypper refresh` to check package manager as `zypper search --installed-only` didnt seem to work.

also added a return statement after finding os `PRETTY_NAME`. Seemed to error otherwise even though `cat /etc/os-release` doesn't return anything odd

edit: Did not add any changes or installations for intel drivers (igpu or ngpu) as those links used .deb files which arent compatible with opensuse, which can use rpm)