### PR TITLE
fix(onvif_util): add_library use STATIC only.

### DIFF
--- a/onvif-util/CMakeLists.txt
+++ b/onvif-util/CMakeLists.txt
@@ -33,7 +33,7 @@ else()
     find_package(LibXml2 REQUIRED)
 endif()
 
-add_library(libonvif STATIC SHARED
+add_library(libonvif STATIC
     ../libonvif/src/onvif.c
     ../libonvif/src/cencode.c
     ../libonvif/src/sha1.c


### PR DESCRIPTION
 fix vcpkg + windows build failed. (LINK ERR, libonvif.lib not found)

add_library shouldn't use STATIC and SHARED at the same time.

to build with vcpkg:
vcpkg install libxml2
cmake -B build -DCMAKE_TOOLCHAIN_FILE="path\to\vcpkg.cmake" cmake --build build --config Release -j